### PR TITLE
Add enemy death animation and improve death logic

### DIFF
--- a/Assets/EnemyAsset/Animations/Enemy.controller
+++ b/Assets/EnemyAsset/Animations/Enemy.controller
@@ -12,6 +12,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -1539654724654753013}
+  - {fileID: -8882689700930761721}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -27,6 +28,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-8882689700930761721
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: enemyDead
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -604361412137532198}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.375
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-6844757797048754926
 AnimatorState:
   serializedVersion: 6
@@ -107,6 +133,32 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &-604361412137532198
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 'Enemy_dead '
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: d5cc64f891cdeca44b9dce71521433d2, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -124,6 +176,12 @@ AnimatorController:
     m_Controller: {fileID: 9100000}
   - m_Name: enemyWalk
     m_Type: 1
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: enemyDead
+    m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
@@ -231,13 +289,16 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -8992058734269525112}
     m_Position: {x: -70, y: 260, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -604361412137532198}
+    m_Position: {x: -70, y: 380, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: -60, y: 200, z: 0}
+  m_AnyStatePosition: {x: 450, y: 70, z: 0}
   m_EntryPosition: {x: 200, y: 130, z: 0}
-  m_ExitPosition: {x: 520, y: 220, z: 0}
+  m_ExitPosition: {x: 720, y: 200, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -5174483740572898742}

--- a/Assets/EnemyAsset/Animations/Enemy_dead.anim
+++ b/Assets/EnemyAsset/Animations/Enemy_dead.anim
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Enemy_dead
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 6991849013916550155, guid: 29ba92ebaa6f6964083271810310d1ca, type: 3}
+    - time: 0.125
+      value: {fileID: -276728812324164698, guid: 29ba92ebaa6f6964083271810310d1ca, type: 3}
+    - time: 0.25
+      value: {fileID: 3156895337291164288, guid: 29ba92ebaa6f6964083271810310d1ca, type: 3}
+    - time: 0.375
+      value: {fileID: 1400002288684528572, guid: 29ba92ebaa6f6964083271810310d1ca, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 8
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 6991849013916550155, guid: 29ba92ebaa6f6964083271810310d1ca, type: 3}
+    - {fileID: -276728812324164698, guid: 29ba92ebaa6f6964083271810310d1ca, type: 3}
+    - {fileID: 3156895337291164288, guid: 29ba92ebaa6f6964083271810310d1ca, type: 3}
+    - {fileID: 1400002288684528572, guid: 29ba92ebaa6f6964083271810310d1ca, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.5
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/EnemyAsset/Animations/Enemy_dead.anim.meta
+++ b/Assets/EnemyAsset/Animations/Enemy_dead.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5cc64f891cdeca44b9dce71521433d2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Based Game Area Design and Layout Processes.unity
+++ b/Assets/Scenes/Based Game Area Design and Layout Processes.unity
@@ -1700,7 +1700,7 @@ MonoBehaviour:
   groundCheckRadius: 0.1
   attackRate: 2
   attackDistance: 0.29
-  attackDamage: 25
+  attackDamage: 100
   groundCheck: {fileID: 1178694150}
   groundLayer:
     serializedVersion: 2
@@ -8693,7 +8693,7 @@ Transform:
   m_GameObject: {fileID: 1970413798}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4.89, y: -0.275, z: 0}
+  m_LocalPosition: {x: -0.655, y: -0.275, z: 0}
   m_LocalScale: {x: 0.96844894, y: 0.9684489, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Assets/Scripts/Enemy/EnemyStats.cs
+++ b/Assets/Scripts/Enemy/EnemyStats.cs
@@ -26,6 +26,8 @@ public class EnemyStats : MonoBehaviour
     public Transform attackPoint;
     public float attackDistance=3f;
 
+    bool isDead = false;
+
     void Start()
     {
         currentHealth = enemyHealth;
@@ -50,7 +52,7 @@ public class EnemyStats : MonoBehaviour
             return; 
         }
 
-        if (player != null)
+        if (player != null && isDead == false)
         {
             float distanceToPlayer = Vector2.Distance(transform.position, player.transform.position);
 
@@ -142,7 +144,9 @@ public class EnemyStats : MonoBehaviour
 
         if (currentHealth <= 0)
         {
-            Destroy(gameObject);
+            anim.SetTrigger("enemyDead");
+            isDead = true;
+            Destroy(gameObject, 0.9f);
         }
     }
 }


### PR DESCRIPTION
Introduced 'Enemy_dead' animation and updated the animator controller to handle enemy death via the 'enemyDead' trigger. Modified EnemyStats to play the death animation and delay object destruction, and adjusted scene parameters for attack damage and enemy position.