### PR TITLE
Add enemy damage and player collision handling

### DIFF
--- a/Assets/Scenes/Based Game Area Design and Layout Processes.unity
+++ b/Assets/Scenes/Based Game Area Design and Layout Processes.unity
@@ -1506,6 +1506,7 @@ GameObject:
   - component: {fileID: 314461843}
   - component: {fileID: 314461844}
   - component: {fileID: 314461845}
+  - component: {fileID: 314461846}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -1742,6 +1743,43 @@ MonoBehaviour:
   maxMana: 0
   currentMana: 0
   manaBar: {fileID: 660008199}
+--- !u!70 &314461846
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 314461837}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0.003234148, y: -0.6999715}
+  m_Size: {x: 0.45906687, y: 0.6725863}
+  m_Direction: 0
 --- !u!1 &341462386
 GameObject:
   m_ObjectHideFlags: 0
@@ -8716,6 +8754,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::EnemyStats
   enemyHealth: 100
   enemyspeed: 2
+  enemyDamage: 10
   Player: {fileID: 314461841}
   knockbackDuration: 0.3
   knockbackForce: 3

--- a/Assets/Scripts/Enemy/EnemyStats.cs
+++ b/Assets/Scripts/Enemy/EnemyStats.cs
@@ -6,6 +6,7 @@ public class EnemyStats : MonoBehaviour
 {
     public float enemyHealth=100f;
     public float enemyspeed = 2f;  
+    public float enemyDamage = 10f;
     float currentHealth;
     GameObject player;
     

--- a/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Assets/Scripts/Player/PlayerHealth.cs
@@ -26,5 +26,17 @@ public class PlayerHealth : MonoBehaviour
             healthBar.fillAmount = currentHealth / 100;
         }
     }
+    void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.gameObject.CompareTag("Enemy"))
+        {
+            currentHealth -= collision.gameObject.GetComponent<EnemyStats>().enemyDamage;
+            
+            if (currentHealth <= 0)
+            {
+                Destroy(gameObject);
+            }
+        }
+    }   
 
 }


### PR DESCRIPTION
Introduced an enemyDamage property to EnemyStats and updated the scene to include it. PlayerHealth now handles collisions with enemies, reducing health based on enemyDamage and destroying the player object when health reaches zero. Added a CapsuleCollider2D to the Player GameObject for collision detection.